### PR TITLE
Disable checkout button when the cart is empty

### DIFF
--- a/static/js/disableCheckout.js
+++ b/static/js/disableCheckout.js
@@ -1,9 +1,7 @@
 "use strict";
 window.addEventListener("DOMContentLoaded", () => {
     var cart = Cart.get();
-    console.log("Llego aca")
     if (cart.isEmpty())
-        console.log("Cart: "+cart+". Is empty")
         document.getElementById("checkout-btn").style.pointerEvents = "none";
         document.getElementById("checkout-btn").style.opacity = "0.5";
 });

--- a/static/js/disableCheckout.js
+++ b/static/js/disableCheckout.js
@@ -1,0 +1,9 @@
+"use strict";
+window.addEventListener("DOMContentLoaded", () => {
+    var cart = Cart.get();
+    console.log("Llego aca")
+    if (cart.isEmpty())
+        console.log("Cart: "+cart+". Is empty")
+        document.getElementById("checkout-btn").style.pointerEvents = "none";
+        document.getElementById("checkout-btn").style.opacity = "0.5";
+});

--- a/templates/components/header.html
+++ b/templates/components/header.html
@@ -78,8 +78,8 @@
                                     <h5>SUBTOTAL: $<span id="order-subtotal">2940.00</span></h5>
                                 </div>
                                 <div class="cart-btns">
-                                    <a href="#">View Cart</a>
-                                    <a href="/checkout">Checkout  <i class="fa fa-arrow-circle-right"></i></a>
+                                    <a id="check-cart-btn" href="#">View Cart</a>
+                                    <a id="checkout-btn" href="/checkout">Checkout  <i class="fa fa-arrow-circle-right"></i></a>
                                 </div>
                             </div>
                         </div>

--- a/templates/layout.html
+++ b/templates/layout.html
@@ -62,5 +62,6 @@
 		<script src="js/enums.js"></script>
 		<script src="js/cart.js"></script>
 		<script src="js/getProducts.js"></script>
+		<script src="js/disableCheckout.js"></script>
 	</body>
 </html>


### PR DESCRIPTION
Cuando se carga la pagina se verifica si el carrito esta vacío, de ser así se inhabilita el botón de checkout. Con eso ya no es necesario redirigir al usuario a la pagina principal cuando le da al boton estando el carrito vacío. Sería bueno eliminar esa otra funcionalidad de checkout.js